### PR TITLE
PADV-502: Add LTI 1.3 access token endpoint

### DIFF
--- a/lti_store/apps.py
+++ b/lti_store/apps.py
@@ -4,4 +4,12 @@ from django.apps import AppConfig
 class LtiStoreConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "lti_store"
-    plugin_app = {}
+    plugin_app = {
+        "url_config": {
+            "lms.djangoapp": {
+                "namespace": name,
+                "regex": f"^{name}/",
+                "relative_path": "urls",
+            },
+        },
+    }

--- a/lti_store/exceptions.py
+++ b/lti_store/exceptions.py
@@ -1,0 +1,48 @@
+"""Custom exceptions for lti_store app."""
+
+
+class Lti1p3Exception(Exception):
+    """Base exception for LTI 1.3."""
+
+    message = None
+
+    def __init__(self, message=None):
+        if not message:
+            message = self.message
+        super().__init__(message)
+
+
+class TokenSignatureExpired(Lti1p3Exception):
+    message = "The token signature has expired."
+
+
+class NoSuitableKeys(Lti1p3Exception):
+    message = "JWKS could not be loaded from the URL."
+
+
+class BadJwtSignature(Lti1p3Exception):
+    message = "The JWT signature is invalid."
+
+
+class MalformedJwtToken(Lti1p3Exception):
+    message = "The JWT could not be parsed because it is malformed."
+
+
+class MissingRequiredClaim(Lti1p3Exception):
+    message = "The required claim is missing."
+
+
+class UnsupportedGrantType(Lti1p3Exception):
+    message = "The JWT grant_type is unsupported."
+
+
+class InvalidClaimValue(Lti1p3Exception):
+    message = "The claim has an invalid value."
+
+
+class InvalidRsaKey(Lti1p3Exception):
+    message = "The RSA key could not parsed."
+
+
+class RsaKeyNotSet(Lti1p3Exception):
+    message = "The RSA key is not set."

--- a/lti_store/key_handlers.py
+++ b/lti_store/key_handlers.py
@@ -1,0 +1,279 @@
+"""LTI 1.3 - Key handlers.
+
+This module handles validating messages sent by the tool, generating
+access tokens and generating the platform public keyset.
+"""
+import codecs
+import copy
+import time
+import json
+
+from Cryptodome.PublicKey import RSA
+from jwkest import BadSignature, BadSyntax, WrongNumberOfParts, jwk
+from jwkest.jwk import RSAKey, load_jwks_from_url
+from jwkest.jws import JWS, NoSuitableSigningKeys
+from jwkest.jwt import JWT
+
+from lti_store.exceptions import (
+    RsaKeyNotSet,
+    InvalidRsaKey,
+    NoSuitableKeys,
+    TokenSignatureExpired,
+    MalformedJwtToken,
+    BadJwtSignature,
+    InvalidClaimValue,
+)
+
+
+class ToolKeyHandler:
+    """LTI 1.3 Tool JWT Handler.
+
+    Uses a tool public keys or keysets URL to retrieve
+    a key and validate a message sent by the tool.
+
+    This is primarily used by the Access Token endpoint
+    in order to validate the JWT Signature of messages
+    signed with the tools signature.
+
+    Attributes:
+        keyset_url (:obj:`str`, optional): Tool Keyset URL.
+        public_key (:obj:`str`, optional): Tool Public Key.
+
+    """
+
+    def __init__(self, public_key=None, keyset_url=None):
+        """Instance message validator.
+
+        Import a public key from the tool by either using a keyset url
+        or a combination of public key + key id.
+
+        Keyset URL takes precedence because it makes key rotation easier to do.
+
+        Args:
+            public_key (:obj:`str`, optional): Tool Public Key.
+            keyset_url (:obj:`str`, optional): Tool Keyset URL.
+
+        Raises:
+            InvalidRsaKey: Invalid public key loaded.
+
+        """
+        # Only store keyset URL to avoid blocking the class
+        # instancing on an external url, which is only used
+        # when validating a token.
+        self.keyset_url = keyset_url
+        self.public_key = None
+
+        if public_key:
+            try:
+                # Import key and save to internal state.
+                new_key = RSAKey(use="sig")
+                new_key.load_key(
+                    RSA.import_key(codecs.decode(public_key, "unicode_escape")),
+                )
+                self.public_key = new_key
+            except ValueError as err:
+                raise InvalidRsaKey() from err
+
+    def _get_keyset(self, key_id=None):
+        """Get keyset from available sources.
+
+        If using a RSA key, forcefully set the key id
+        to match the one from the JWT token.
+
+        Args:
+            key_id (:obj:`str`, optional): Private Key ID.
+
+        Raises:
+            NoSuitableKeys: jwkest fails to load keyset URL.
+
+        """
+        keyset = []
+
+        if self.keyset_url:
+            try:
+                keys = load_jwks_from_url(self.keyset_url)
+                keyset.extend(keys)
+            except Exception as err:
+                # Broad Exception is required here because jwkest raises
+                # an Exception object explicitly.
+                # Beware that many different scenarios are being handled
+                # as an invalid key when the JWK loading fails.
+                raise NoSuitableKeys() from err
+
+        if self.public_key and key_id:
+            # Fill in key id of stored key.
+            # This is needed because if the JWS is signed with a
+            # key with a kid, pyjwkest doesn't match them with
+            # keys without kid (kid=None) and fails verification
+            self.public_key.kid = key_id
+
+            # Add to keyset.
+            keyset.append(self.public_key)
+
+        return keyset
+
+    def validate_and_decode(self, token):
+        """Check if a message sent by the tool is valid.
+
+        The authorization server decodes the JWT and MUST validate the values for the
+        iss, sub, exp, aud and jti claims.
+
+        Args:
+            token (str): JWT Token.
+
+        Raises:
+            TokenSignatureExpired: JWT token signature is expired.
+            NoSuitableKeys: JWKS could not be loaded.
+            MalformedJwtToken: JWT token is malformed.
+            BadJwtSignature: JWT token signature is invalid.
+
+        References:
+            https://www.imsglobal.org/spec/security/v1p0/#using-oauth-2-0-client-credentials-grant
+
+        """
+        try:
+            # Get kid from JWT header.
+            jwt = JWT().unpack(token)
+
+            # Verify message signature.
+            message = JWS().verify_compact(
+                token,
+                keys=self._get_keyset(jwt.headers.get("kid")),
+            )
+
+            # If message is valid, check expiration from JWT.
+            if "exp" in message and message.get("exp") < time.time():
+                raise TokenSignatureExpired()
+
+            # Return decoded message.
+            return message
+        except NoSuitableSigningKeys as err:
+            raise NoSuitableKeys() from err
+        except (BadSyntax, WrongNumberOfParts) as err:
+            raise MalformedJwtToken() from err
+        except BadSignature as err:
+            raise BadJwtSignature() from err
+
+
+class PlatformKeyHandler:
+    """Platform RSA Key handler.
+
+    This class loads the platform key and is responsible for
+    encoding JWT messages and exporting public keys.
+
+    Attributes:
+        key (:obj:`str`, optional): RSA Key.
+
+    """
+
+    def __init__(self, key_pem, key_id=None):
+        """Import key when instancing class if a key is present.
+
+        Args:
+            key_pem (str): RSA Private Key PEM.
+            key_id (:obj:`str`, optional): Private Key ID.
+
+        Raises:
+            InvalidRsaKey: Failed to import key.
+
+        """
+        self.key = None
+
+        if key_pem:
+            # Import JWK from RSA key.
+            try:
+                self.key = RSAKey(
+                    kid=key_id,
+                    key=RSA.import_key(key_pem),
+                )
+            except ValueError:
+                raise InvalidRsaKey()
+
+    def encode_and_sign(self, message, expiration=None):
+        """Encode and sign JSON with RSA key.
+
+        Args:
+            message (str): Message to encode.
+            expiration (:obj:`int`, optional): Token expiration.
+
+        Raises:
+            RsaKeyNotSet: RSA key is not set.
+
+        """
+        if not self.key:
+            raise RsaKeyNotSet()
+
+        message_copy = copy.deepcopy(message)
+
+        # Set iat and exp if expiration is set.
+        # https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
+        # https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+        if expiration:
+            message_copy.update(
+                {
+                    "iat": int(round(time.time())),
+                    "exp": int(round(time.time()) + expiration),
+                },
+            )
+
+        # The class instance that sets up the signing operation
+        # An RS 256 key is required for LTI 1.3
+        jws = JWS(message_copy, alg="RS256", cty="JWT")
+
+        # Encode and sign LTI message.
+        return jws.sign_compact([self.key])
+
+    def get_public_jwk(self):
+        """Export Public JWK."""
+        # Return empty keyset if no key is set.
+        if not self.key:
+            return {"keys": []}
+
+        public_keys = jwk.KEYS()
+        public_keys.append(self.key)
+
+        return json.loads(public_keys.dump_jwks())
+
+    def validate_and_decode(self, token, iss=None, aud=None):
+        """Check if a platform token is valid, and return allowed scopes.
+
+        Validates a token sent by the tool using the platform's RSA Key.
+        Optionally validate iss and aud claims if provided.
+
+        Args:
+            token (str): JWT Token.
+            iss (:obj:`str`, optional): Issuer.
+            aud (:obj:`str`, optional): Client ID.
+
+        Raises:
+            TokenSignatureExpired: RSA key is not set.
+            InvalidClaimValue: Missing iss or aud, iss value not expected.
+            NoSuitableKeys: JWKS could not be loaded.
+            MalformedJwtToken: JWT token malformed.
+
+        """
+        try:
+            # Verify message signature.
+            message = JWS().verify_compact(token, keys=[self.key])
+
+            # If message is valid, check expiration from JWT.
+            if "exp" in message and message.get("exp") < time.time():
+                raise TokenSignatureExpired()
+
+            # Validate issuer claim (if present).
+            if iss and ("iss" not in message or message.get("iss") != iss):
+                raise InvalidClaimValue(
+                    "The required iss claim is either missing or does "
+                    "not match the expected iss value."
+                )
+
+            # Validate audience claim (if present).
+            if aud and ("aud" not in message or aud not in message.get("aud")):
+                raise InvalidClaimValue("The required aud claim is missing.")
+
+            # Return token contents.
+            return message
+        except NoSuitableSigningKeys as err:
+            raise NoSuitableKeys() from err
+        except BadSyntax as err:
+            raise MalformedJwtToken() from err

--- a/lti_store/tests/test_key_handlers.py
+++ b/lti_store/tests/test_key_handlers.py
@@ -1,0 +1,342 @@
+from unittest.mock import Mock, patch, call
+
+import ddt
+from Cryptodome.PublicKey import RSA
+from django.test.testcases import TestCase
+from jwkest import BadSignature, BadSyntax, WrongNumberOfParts
+from jwkest.jwk import RSAKey
+from jwkest.jws import JWS
+from jwkest.jwt import JWT
+
+from lti_store import exceptions
+from lti_store.key_handlers import PlatformKeyHandler, ToolKeyHandler
+
+
+TOKEN = "test-token"
+KID = "test-kid"
+KEYSET = "test-keyset"
+KEYSET_URL = "test-keyset-url"
+UNPACK = Mock(headers={"kid": KID})
+MSG = {"iss": "test-issuer", "aud": "test-aud"}
+SIGNED_MSG = "test-signed-message"
+
+
+@ddt.ddt
+class TestPlatformKeyHandler(TestCase):
+    """
+    Unit tests for PlatformKeyHandler.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rsa_key_id = "1"
+        self.rsa_key = RSA.generate(2048).export_key("PEM")
+        self.key_handler = PlatformKeyHandler(
+            key_pem=self.rsa_key, key_id=self.rsa_key_id
+        )
+
+    @patch("lti_store.key_handlers.copy.deepcopy", return_value=MSG)
+    @patch.object(JWS, "__init__", return_value=None)
+    @patch.object(JWS, "sign_compact", return_value=SIGNED_MSG)
+    def test_encode_and_sign(self, sign_compact_mock, jws_mock, deepcopy_mock):
+        """
+        Test if a message was correctly signed with RSA key.
+        """
+        self.assertEqual(self.key_handler.encode_and_sign(MSG), SIGNED_MSG)
+        deepcopy_mock.assert_called_once_with(MSG)
+        jws_mock.assert_called_once_with(MSG, alg="RS256", cty="JWT")
+        sign_compact_mock.assert_called_once_with([self.key_handler.key])
+
+    @patch("time.time", return_value=1000)
+    @patch("lti_store.key_handlers.copy.deepcopy")
+    @patch.object(JWS, "__init__", return_value=None)
+    @patch.object(JWS, "sign_compact", return_value=SIGNED_MSG)
+    def test_encode_and_sign_with_exp(
+        self,
+        sign_compact_mock,
+        jws_mock,
+        deepcopy_mock,
+        mock_time,
+    ):
+        """
+        Test if a message was correctly signed and has exp and iat parameters.
+        """
+        message_mock = Mock()
+        deepcopy_mock.return_value = message_mock
+
+        self.assertEqual(
+            self.key_handler.encode_and_sign(message_mock, expiration=1000),
+            SIGNED_MSG,
+        )
+        deepcopy_mock.assert_called_once_with(message_mock)
+        message_mock.update.assert_called_once_with({"iat": 1000, "exp": 2000})
+        mock_time.assert_has_calls([call(), call()])
+        jws_mock.assert_called_once_with(message_mock, alg="RS256", cty="JWT")
+        sign_compact_mock.assert_called_once_with([self.key_handler.key])
+
+    def test_invalid_rsa_key(self):
+        """
+        Check that class raises when trying to import invalid RSA Key.
+        """
+        with self.assertRaises(exceptions.InvalidRsaKey):
+            PlatformKeyHandler(key_pem="invalid PEM input")
+
+    def test_empty_rsa_key(self):
+        """
+        Check that class doesn't fail instancing when not using a key.
+        """
+        empty_key_handler = PlatformKeyHandler(key_pem="")
+
+        # Trying to encode a message should fail
+        with self.assertRaises(exceptions.RsaKeyNotSet):
+            empty_key_handler.encode_and_sign({})
+
+        # Public JWK should return an empty value
+        self.assertEqual(empty_key_handler.get_public_jwk(), {"keys": []})
+
+    @patch("time.time", return_value=1000)
+    @patch.object(JWS, "verify_compact")
+    def test_validate_and_decode(self, verify_compact_mock, mock_time):
+        """
+        Test validate and decode with all parameters.
+        """
+        decoded_message = {**MSG, "iat": 1000, "exp": 2000}
+        verify_compact_mock.return_value = decoded_message
+
+        signed_token = self.key_handler.encode_and_sign(MSG, expiration=1000)
+
+        self.assertEqual(
+            self.key_handler.validate_and_decode(signed_token),
+            decoded_message,
+        )
+        verify_compact_mock.assert_called_once_with(
+            signed_token, keys=[self.key_handler.key]
+        )
+        mock_time.assert_has_calls([call(), call(), call()])
+
+    @patch("time.time", return_value=1000)
+    def test_validate_and_decode_expired(self, mock_time):
+        """
+        Test validate and decode with all parameters.
+        """
+        signed_token = self.key_handler.encode_and_sign({}, expiration=-10)
+
+        with self.assertRaises(exceptions.TokenSignatureExpired):
+            self.key_handler.validate_and_decode(signed_token)
+
+    def test_validate_and_decode_invalid_iss(self):
+        """
+        Test validate and decode with invalid iss.
+        """
+        signed_token = self.key_handler.encode_and_sign({"iss": "wrong"})
+
+        with self.assertRaises(exceptions.InvalidClaimValue):
+            self.key_handler.validate_and_decode(signed_token, iss="right")
+
+    def test_validate_and_decode_invalid_aud(self):
+        """
+        Test validate and decode with invalid aud.
+        """
+        signed_token = self.key_handler.encode_and_sign({"aud": "wrong"})
+
+        with self.assertRaises(exceptions.InvalidClaimValue):
+            self.key_handler.validate_and_decode(signed_token, aud="right")
+
+    def test_validate_and_decode_no_jwt(self):
+        """
+        Test validate and decode with invalid JWT.
+        """
+        with self.assertRaises(exceptions.MalformedJwtToken):
+            self.key_handler.validate_and_decode("1.2.3")
+
+    def test_validate_and_decode_no_keys(self):
+        """
+        Test validate and decode when no keys are available.
+        """
+        signed_token = self.key_handler.encode_and_sign({})
+        self.key_handler.key.kid = "invalid_kid"  # Changing the KID so it doesn't match
+
+        with self.assertRaises(exceptions.NoSuitableKeys):
+            self.key_handler.validate_and_decode(signed_token)
+
+
+@ddt.ddt
+class TestToolKeyHandler(TestCase):
+    """
+    Unit tests for ToolKeyHandler.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.rsa_key_id = "1"
+
+        # Generate RSA and save exports
+        rsa_key = RSA.generate(2048)
+        self.key = RSAKey(key=rsa_key, kid=self.rsa_key_id)
+        self.public_key = rsa_key.publickey().export_key()
+
+        # Key handler
+        self.key_handler = None
+
+    def _setup_key_handler(self):
+        """
+        Set up a instance of the key handler.
+        """
+        self.key_handler = ToolKeyHandler(public_key=self.public_key)
+
+    def test_import_rsa_key(self):
+        """
+        Check if the class is correctly instanced using a valid RSA key.
+        """
+        ToolKeyHandler(public_key=self.public_key)
+
+    def test_import_invalid_rsa_key(self):
+        """
+        Check if the class errors out when using a invalid RSA key.
+        """
+        with self.assertRaises(exceptions.InvalidRsaKey):
+            ToolKeyHandler(public_key="invalid-key")
+
+    def test_get_empty_keyset(self):
+        """
+        Test getting an empty keyset.
+        """
+        self.assertEqual(
+            ToolKeyHandler()._get_keyset(),
+            [],
+        )
+
+    @patch("lti_store.key_handlers.load_jwks_from_url", return_value="k")
+    def test_get_keyset_with_keyset_url(self, load_jwks_from_url_mock):
+        """
+        Check getting a keyset from a keyset URL.
+        """
+        keyset = ToolKeyHandler(keyset_url=KEYSET_URL)._get_keyset()
+
+        self.assertEqual(len(keyset), 1)
+        self.assertEqual(keyset[0], "k")
+        load_jwks_from_url_mock.assert_called_once_with(KEYSET_URL)
+
+    @patch("lti_store.key_handlers.load_jwks_from_url", side_effect=Exception)
+    def test_get_keyset_with_invalid_keyset_url(self, load_jwks_from_url_mock):
+        """
+        Check getting a keyset from an invalid keyset URL.
+        """
+        with self.assertRaises(exceptions.NoSuitableKeys):
+            ToolKeyHandler(keyset_url=KEYSET_URL)._get_keyset()
+
+    def test_get_keyset_with_pub_key(self):
+        """
+        Check getting a keyset from a RSA key.
+        """
+        self._setup_key_handler()
+
+        keyset = self.key_handler._get_keyset(key_id=self.rsa_key_id)
+
+        self.assertEqual(len(keyset), 1)
+        self.assertEqual(keyset[0].kid, self.rsa_key_id)
+
+    @patch("time.time", return_value=1000)
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact")
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+        mock_time,
+    ):
+        """
+        Check that the validate and decode works.
+        """
+        message = {"exp": 1200}
+        verify_compact_mock.return_value = message
+        self._setup_key_handler()
+
+        self.assertEqual(self.key_handler.validate_and_decode(TOKEN), message)
+        unpack_mock.assert_called_once_with(TOKEN)
+        get_keyset_mock.assert_called_once_with(KID)
+        verify_compact_mock.assert_called_once_with(TOKEN, keys=KEYSET)
+        mock_time.assert_called_once_with()
+
+    @patch("time.time", return_value=1000)
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact", return_value={"exp": 910})
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode_expired(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+        mock_time,
+    ):
+        """
+        Check that the validate and decode raises when signature expires.
+        """
+        self._setup_key_handler()
+
+        with self.assertRaises(exceptions.TokenSignatureExpired):
+            self.key_handler.validate_and_decode(TOKEN)
+
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact", side_effect=exceptions.NoSuitableKeys)
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode_no_keys(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+    ):
+        """
+        Check that the validate and decode raises when no keys are found.
+        """
+        with self.assertRaises(exceptions.NoSuitableKeys):
+            ToolKeyHandler().validate_and_decode(TOKEN)
+
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact", side_effect=BadSyntax(None, None))
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode_bad_syntax(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+    ):
+        """
+        Check that the validate and decode raises BadSyntax on invalid token.
+        """
+        with self.assertRaises(exceptions.MalformedJwtToken):
+            ToolKeyHandler().validate_and_decode(TOKEN)
+
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact", side_effect=WrongNumberOfParts)
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode_wrong_number_of_parts(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+    ):
+        """
+        Check that the validate and decode raises WrongNumberOfParts on invalid token.
+        """
+        with self.assertRaises(exceptions.MalformedJwtToken):
+            ToolKeyHandler().validate_and_decode(TOKEN)
+
+    @patch.object(JWT, "unpack", return_value=UNPACK)
+    @patch.object(JWS, "verify_compact", side_effect=BadSignature)
+    @patch.object(ToolKeyHandler, "_get_keyset", return_value=KEYSET)
+    def test_validate_and_decode_bad_signature(
+        self,
+        get_keyset_mock,
+        verify_compact_mock,
+        unpack_mock,
+    ):
+        """
+        Check that the validate and decode raises BadSignature on invalid token.
+        """
+        with self.assertRaises(exceptions.BadJwtSignature):
+            ToolKeyHandler().validate_and_decode(TOKEN)

--- a/lti_store/tests/test_urls.py
+++ b/lti_store/tests/test_urls.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from django.urls import resolve, reverse
+
+from lti_store.views import access_token_endpoint
+
+
+class TestUrls(TestCase):
+    """Test URL configuration."""
+
+    def test_lti_tool_login_url_resolves(self):
+        """Test access_token_endpoint URL can be resolved."""
+        self.assertEqual(
+            resolve(reverse("access_token", kwargs={"lti_config_id": 1})).func,
+            access_token_endpoint,
+        )

--- a/lti_store/tests/test_utils.py
+++ b/lti_store/tests/test_utils.py
@@ -1,0 +1,18 @@
+from django.test import TestCase, override_settings
+
+from lti_store.utils import get_lti_api_base
+
+
+class TestUtils(TestCase):
+    """Test utils functions."""
+
+    def test_get_lti_api_base(self):
+        """Test get_lti_api base function."""
+        with override_settings(LTI_API_BASE="test-lti-api-base"):
+            self.assertEqual(get_lti_api_base(), "test-lti-api-base")
+
+        with override_settings(LTI_BASE="test-lti-base"):
+            self.assertEqual(get_lti_api_base(), "test-lti-base")
+
+        with override_settings(LMS_ROOT_URL="test-lms-root-url"):
+            self.assertEqual(get_lti_api_base(), "test-lms-root-url")

--- a/lti_store/tests/test_views.py
+++ b/lti_store/tests/test_views.py
@@ -1,0 +1,251 @@
+from unittest.mock import Mock, patch
+from http import HTTPStatus
+
+from django.urls import reverse
+from django.test import Client, TestCase
+from lti_store.models import (
+    LTIVersion,
+    ExternalLtiConfiguration,
+)
+from lti_store.key_handlers import PlatformKeyHandler, ToolKeyHandler
+from lti_store.exceptions import (
+    MalformedJwtToken,
+    TokenSignatureExpired,
+    NoSuitableKeys,
+)
+
+CONFIG_ID = 1
+CLIENT_ID = "test-client-id"
+PUBLIC_KEY = "test-public-key"
+KEYSET_URL = "test-keyset-url"
+PRIVATE_KEY = "test-private-key"
+PRIVATE_KEY_ID = "test-private-key-id"
+API_BASE = "test-lti-base"
+JWT_TOKEN = "test-jwt-token"
+ACCESS_TOKEN = "test-access-token"
+EXPIRATION = 3600
+SCOPES = [
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+    "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+]
+SCOPE_STR = " ".join(SCOPES)
+CONTENT_TYPE = "application/x-www-form-urlencoded"
+
+
+class TestAccessTokenEndpointView(TestCase):
+    """Test access token endpoint view."""
+
+    def setUp(self):
+        """Test fixtures setup."""
+        self.client = Client()
+        self.url = reverse("access_token", kwargs={"lti_config_id": CONFIG_ID})
+        self.external_config = Mock(
+            version=LTIVersion.LTI_1P3,
+            lti_1p3_client_id=CLIENT_ID,
+            lti_1p3_tool_public_key=PUBLIC_KEY,
+            lti_1p3_tool_keyset_url=KEYSET_URL,
+            lti_1p3_private_key=PRIVATE_KEY,
+            lti_1p3_private_key_id=PRIVATE_KEY_ID,
+        )
+        self.request_data = [
+            ("grant_type", "client_credentials"),
+            ("client_assertion_type", ""),
+            ("client_assertion", JWT_TOKEN),
+            ("scope", " ".join(list(map(str, SCOPES)))),
+        ]
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.urllib.parse.parse_qsl")
+    @patch.object(ToolKeyHandler, "__init__", return_value=None)
+    @patch.object(ToolKeyHandler, "validate_and_decode", return_value=None)
+    @patch.object(PlatformKeyHandler, "__init__", return_value=None)
+    @patch.object(PlatformKeyHandler, "encode_and_sign", return_value=ACCESS_TOKEN)
+    @patch("lti_store.views.get_lti_api_base", return_value=API_BASE)
+    def test_access_token_request(
+        self,
+        get_lti_api_base_mock,
+        encode_and_sign_mock,
+        platform_key_handler_mock,
+        validate_and_decode_mock,
+        tool_key_handler_mock,
+        parse_qsl_mock,
+        objects_mock,
+    ):
+        """Test access token request."""
+        objects_mock.get.return_value = self.external_config
+        parse_qsl_mock.return_value = self.request_data
+
+        response = self.client.post(self.url, content_type=CONTENT_TYPE)
+
+        self.assertJSONEqual(
+            response.content,
+            {
+                "access_token": ACCESS_TOKEN,
+                "token_type": "bearer",
+                "expires_in": EXPIRATION,
+                "scope": SCOPE_STR,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        objects_mock.get.assert_called_once_with(id=CONFIG_ID)
+        parse_qsl_mock.assert_called_once_with(
+            response.wsgi_request.body.decode("utf-8"),
+            keep_blank_values=True,
+        )
+        get_lti_api_base_mock.assert_called_once_with()
+        tool_key_handler_mock.assert_called_once_with(
+            public_key=PUBLIC_KEY,
+            keyset_url=KEYSET_URL,
+        )
+        validate_and_decode_mock.assert_called_once_with(JWT_TOKEN)
+        platform_key_handler_mock.assert_called_once_with(
+            PRIVATE_KEY,
+            PRIVATE_KEY_ID,
+        )
+        encode_and_sign_mock.assert_called_once_with(
+            {
+                "sub": CLIENT_ID,
+                "iss": API_BASE,
+                "scopes": SCOPE_STR,
+            },
+            expiration=EXPIRATION,
+        )
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.log.warning")
+    def test_invalid_config_id(self, warning_mock, objects_mock):
+        """Test request with invalid external configuration ID."""
+        objects_mock.get.side_effect = ExternalLtiConfiguration.DoesNotExist
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        warning_mock.assert_called_once_with(
+            "Can't find LTI external configuration with ID %s",
+            CONFIG_ID,
+        )
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    def test_invalid_lti_version(self, objects_mock):
+        """Test request with invalid external configuration version."""
+        self.external_config.version = LTIVersion.LTI_1P1
+        objects_mock.get.return_value = self.external_config
+
+        response = self.client.post(self.url)
+
+        self.assertJSONEqual(
+            response.content,
+            {"error": "invalid_lti_version"},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    def test_missing_required_claim(self, objects_mock):
+        """Test request with missing required claims."""
+        objects_mock.get.return_value = self.external_config
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"error": "invalid_request"}',
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.urllib.parse.parse_qsl")
+    @patch.object(
+        ToolKeyHandler,
+        "__init__",
+        return_value=None,
+        side_effect=MalformedJwtToken,
+    )
+    def test_malformed_jwt_token(
+        self,
+        tool_key_handler_mock,
+        parse_qsl_mock,
+        objects_mock,
+    ):
+        """Test request with malformed JWT."""
+        objects_mock.get.return_value = self.external_config
+        parse_qsl_mock.return_value = self.request_data
+
+        response = self.client.post(self.url, content_type=CONTENT_TYPE)
+
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"error": "invalid_grant"}',
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.urllib.parse.parse_qsl")
+    @patch.object(
+        ToolKeyHandler,
+        "__init__",
+        return_value=None,
+        side_effect=TokenSignatureExpired,
+    )
+    def test_token_signature_expired(
+        self,
+        tool_key_handler_mock,
+        parse_qsl_mock,
+        objects_mock,
+    ):
+        """Test request with expired token signature."""
+        objects_mock.get.return_value = self.external_config
+        parse_qsl_mock.return_value = self.request_data
+
+        response = self.client.post(self.url, content_type=CONTENT_TYPE)
+
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"error": "invalid_grant"}',
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.urllib.parse.parse_qsl")
+    @patch.object(
+        ToolKeyHandler,
+        "__init__",
+        return_value=None,
+        side_effect=NoSuitableKeys,
+    )
+    def test_no_suitable_keys(
+        self,
+        tool_key_handler_mock,
+        parse_qsl_mock,
+        objects_mock,
+    ):
+        """Test request with no suitable keys."""
+        objects_mock.get.return_value = self.external_config
+        parse_qsl_mock.return_value = self.request_data
+
+        response = self.client.post(self.url, content_type=CONTENT_TYPE)
+
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"error": "invalid_client"}',
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    @patch.object(ExternalLtiConfiguration, "objects")
+    @patch("lti_store.views.urllib.parse.parse_qsl")
+    def test_unsupported_grant_type(self, parse_qsl_mock, objects_mock):
+        request_data = self.request_data
+        request_data.pop(0)
+        request_data.append(("grant_type", "unsuported"))
+        parse_qsl_mock.return_value = request_data
+        objects_mock.get.return_value = self.external_config
+
+        response = self.client.post(self.url, content_type=CONTENT_TYPE)
+
+        self.assertEqual(
+            response.content.decode("utf-8"),
+            '{"error": "unsupported_grant_type"}',
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)

--- a/lti_store/urls.py
+++ b/lti_store/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from lti_store.views import access_token_endpoint
+
+urlpatterns = [
+    path(
+        "token/<int:lti_config_id>",
+        access_token_endpoint,
+        name="access_token",
+    ),
+]

--- a/lti_store/utils.py
+++ b/lti_store/utils.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+
+
+def get_lti_api_base():
+    """Returns LTI API base URL.
+
+    This URL is used for LTI API calls. If LTI_API_BASE is set,
+    this will override the default LTI_BASE_URL, if no setting is
+    found the LMS_BASE_URL is returned.
+
+    Returns:
+        LTI API base URL string.
+
+    """
+    if hasattr(settings, "LTI_API_BASE"):
+        return settings.LTI_API_BASE
+    if hasattr(settings, "LTI_BASE"):
+        return settings.LTI_BASE
+    return settings.LMS_ROOT_URL

--- a/lti_store/views.py
+++ b/lti_store/views.py
@@ -1,0 +1,157 @@
+import logging
+import urllib
+from http import HTTPStatus
+
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.http import Http404, JsonResponse
+from lti_store.exceptions import (
+    MissingRequiredClaim,
+    UnsupportedGrantType,
+    MalformedJwtToken,
+    TokenSignatureExpired,
+    NoSuitableKeys,
+)
+from lti_store.models import ExternalLtiConfiguration, LTIVersion
+from lti_store.key_handlers import PlatformKeyHandler, ToolKeyHandler
+from lti_store.utils import get_lti_api_base
+
+log = logging.getLogger(__name__)
+
+LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS = {
+    "grant_type",
+    "client_assertion_type",
+    "client_assertion",
+    "scope",
+}
+
+LTI_1P3_ACCESS_TOKEN_SCOPES = [
+    # LTI-AGS Scopes
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/lineitem",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly",
+    "https://purl.imsglobal.org/spec/lti-ags/scope/score",
+    # LTI-NRPS Scopes
+    "https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly",
+]
+
+
+@csrf_exempt
+@xframe_options_sameorigin
+@require_http_methods(["POST"])
+def access_token_endpoint(request, lti_config_id):
+    """Gate endpoint to enable tools to retrieve access tokens for the LTI 1.3 tool.
+
+    Arguments:
+        lti_config_id (int): ID of the LTI external configuration
+
+    Returns:
+        JsonResponse with access token or error message
+
+    Raises:
+        Http404: LTI external configuration is not found
+        MissingRequiredClaim: Required claims are missing from request data
+        UnsupportedGrantType: Unsupported grant type on request data
+
+    References:
+        Sucess: https://tools.ietf.org/html/rfc6749#section-4.4.3
+        Failure: https://tools.ietf.org/html/rfc6749#section-5.2
+
+    """
+
+    try:
+        config = ExternalLtiConfiguration.objects.get(id=lti_config_id)
+    except ExternalLtiConfiguration.DoesNotExist as exc:
+        log.warning(
+            "Can't find LTI external configuration with ID %s",
+            lti_config_id,
+        )
+        raise Http404 from exc
+
+    if config.version != LTIVersion.LTI_1P3:
+        return JsonResponse(
+            {"error": "invalid_lti_version"},
+            status=HTTPStatus.BAD_REQUEST,
+        )
+
+    # Transform request data to dictionary.
+    token_request_data = dict(
+        urllib.parse.parse_qsl(
+            request.body.decode("utf-8"),
+            keep_blank_values=True,
+        ),
+    )
+
+    try:
+        # Check if all required claims are on request data.
+        for required_claim in LTI_1P3_ACCESS_TOKEN_REQUIRED_CLAIMS:
+            if required_claim not in token_request_data.keys():
+                raise MissingRequiredClaim(
+                    f"The required claim {required_claim} is missing from the JWT.",
+                )
+
+        # Check that grant type is `client_credentials`.
+        if not token_request_data.get("grant_type") == "client_credentials":
+            raise UnsupportedGrantType()
+
+        # Validate JWT token.
+        tool_jwt = ToolKeyHandler(
+            public_key=config.lti_1p3_tool_public_key,
+            keyset_url=config.lti_1p3_tool_keyset_url,
+        )
+        tool_jwt.validate_and_decode(token_request_data.get("client_assertion"))
+
+        # Get platform key handler.
+        key_handler = PlatformKeyHandler(
+            config.lti_1p3_private_key,
+            config.lti_1p3_private_key_id,
+        )
+
+        # Check scopes and only return valid and supported ones.
+        valid_scopes = []
+        requested_scopes = token_request_data.get("scope").split(" ")
+
+        for scope in requested_scopes:
+            if scope in LTI_1P3_ACCESS_TOKEN_SCOPES:
+                valid_scopes.append(scope)
+
+        # Scopes are space separated as described in https://tools.ietf.org/html/rfc6749
+        scopes_str = " ".join(valid_scopes)
+
+        # This response is compliant with RFC 6749
+        # https://tools.ietf.org/html/rfc6749#section-4.4.3
+        return JsonResponse(
+            {
+                "access_token": key_handler.encode_and_sign(
+                    {
+                        "sub": config.lti_1p3_client_id,
+                        "iss": get_lti_api_base(),
+                        "scopes": scopes_str,
+                    },
+                    # Create token valid for 3600 seconds (1h) as per specification
+                    # https://www.imsglobal.org/spec/security/v1p0/#expires_in-values-and-renewing-the-access-token
+                    expiration=3600,
+                ),
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": scopes_str,
+            },
+        )
+
+    # Handle errors and return a proper response.
+    except MissingRequiredClaim:
+        # Missing required request attibutes.
+        return JsonResponse({"error": "invalid_request"}, status=HTTPStatus.BAD_REQUEST)
+    except (MalformedJwtToken, TokenSignatureExpired):
+        # Invalid malformed grant token or token expired.
+        return JsonResponse({"error": "invalid_grant"}, status=HTTPStatus.BAD_REQUEST)
+    except NoSuitableKeys:
+        # Can't validate token using available keys.
+        return JsonResponse({"error": "invalid_client"}, status=HTTPStatus.BAD_REQUEST)
+    except UnsupportedGrantType:
+        # Requested grant type is unsupported.
+        return JsonResponse(
+            {"error": "unsupported_grant_type"},
+            status=HTTPStatus.BAD_REQUEST,
+        )

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 pytest-django
 black
+ddt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,11 +10,17 @@ attrs==21.4.0
     # via pytest
 black==22.1.0
     # via -r requirements/dev.in
+certifi==2023.5.7
+    # via requests
+charset-normalizer==3.1.0
+    # via requests
 click==8.0.4
     # via black
 coverage[toml]==6.3.2
     # via pytest-cov
-django==3.2.12
+ddt==1.6.0
+    # via -r requirements/dev.in
+django==3.2.19
     # via
     #   -r requirements/base.in
     #   openedx-filters
@@ -22,16 +28,26 @@ iniconfig==1.1.1
     # via pytest
 mypy-extensions==0.4.3
     # via black
-openedx-filters==0.5.0
-    # via -r requirements/base.in
+future==0.18.3
+    # via pyjwkest
+idna==3.4
+    # via requests
 packaging==21.3
     # via pytest
 pathspec==0.9.0
     # via black
+openedx-filters==1.2.0
+    # via -r requirements/base.in
 platformdirs==2.5.1
     # via black
 pluggy==1.0.0
     # via pytest
+pycryptodomex==3.17
+    # via
+    #   -r requirements/base.in
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via -r requirements/base.in
 py==1.11.0
     # via pytest
 pyparsing==3.0.7
@@ -45,9 +61,13 @@ pytest-cov==3.0.0
     # via -r requirements/dev.in
 pytest-django==4.5.2
     # via -r requirements/dev.in
-pytz==2021.3
+pytz==2023.3
     # via django
-sqlparse==0.4.2
+requests==2.30.0
+    # via pyjwkest
+six==1.16.0
+    # via pyjwkest
+sqlparse==0.4.4
     # via django
 tomli==2.0.1
     # via
@@ -56,3 +76,5 @@ tomli==2.0.1
     #   pytest
 typing-extensions==4.1.1
     # via black
+urllib3==2.0.2
+    # via requests

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,10 +1,12 @@
 DEBUG = True
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'testdb.sqlite',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "testdb.sqlite",
     }
 }
 
 INSTALLED_APPS = ["lti_store"]
+
+ROOT_URLCONF = "lti_store.urls"


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-502

## Description

This PR adds LTI 1.3 access token endpoint to the plugin views. This endpoint is used by LTI tools to request accesss tokens that they can use to interact with the LTI advantage services (AGS, NPRS) on the LTI platform

## Type of Change

- [x] Add test requirements.
- [x] Add access_token_endpoint view.
- [x] Add URLS configuration.
- [x] Add ToolKeyHandler and PlatformKeyHandler classes.
- [x] Add get_lti_api_base utility.
- [x] Add LTI 1.3 exception classes.
- [x] Add test for views, urls and utils modules.
- [x] Update plugin_app url_config.
- [x] Update test settings ROOT_URLCONF value.
- [x] Update test requirements to match base requirements

## Testing:

- Run the LMS: `make dev.up.lms`
- Run studio: `make dev.up.studio`
- Run ngrok: `ngrok http 18000`
- Set LTI_BASE and LTI_API_BASE on the LMS and Studio settings:
	- LTI_BASE="http://localhost:18000"
	- LTI_API_BASE="https://34a7-190-142-38-224.ngrok-free.app"
- Install xblock-lti-consumer and openedx-ltistore on the LMS and Studio.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI 1.3 consumer XBlock to a course.
- Enable AGS on the LTI consumer XBlock.
- Go to the learning MFE and get the XBlock location using the "Staff Debug Info" button.
- Clone https://github.com/kuipumu/lti1p3_scripts
- Generate a key pair on IMS RI: https://lti-ri.imsglobal.org/keygen/index
- Save them as id_rsa (private key) and id_rsa.pub (public key) on the lti1p3_scripts folder.
- Go to http://localhost:18000/admin/lti_consumer/lticonfiguration/
- Replace the Lti 1p3 internal private key with the id_rsa key.
- Copy the Lti 1p3 client id and Lti 1p3 internal private key id values.
- Go to http://localhost:18000/admin/lti_store/externallticonfiguration/
- Create a new LTI external configuration using the same private key, private key id we set on the XBlock LTI configuration and generated public key.
- Copy the LTI external configuration ID.
- Create a platforms.json on lti1p3_scripts.
- Add an item for each access token endpoints:
```
{
	"lti_store": {
          "client_id": "Lti 1p3 client id",
          "token_url": "http://localhost:18000/lti_store/v1/token/{lti_external_configuration_id}"
	},
	"block": {
          "client_id": "Lti 1p3 client id",
          # User the XBlock access token URL.
          "token_url": "https://34a7-190-142-38-224.ngrok-free.app/api/lti_consumer/v1/token/4d0bfb92-7029-469c-98bf-db91cf022384"
	}
}
```
- Run the token_request.py script: `python3 lti1p3_scripts/token_request.py lti_store`
- Copy the generated access token.
- Go to http://localhost:18000/admin/lti_consumer/ltiagslineitem
- Copy the LTI AGS line item ID of your LTI consumer XBlock.
- Go to http://localhost:18000/admin/external_user_ids/externalid/
- Copy your external user ID.
- Open Postman and import this collection JSON: https://drive.google.com/file/d/1PjXsTj3VTd1Cmhh24x4oXuNz96_qd2Mk/view?usp=sharing
- Edit the "AGS Score" request URL from the LTI 1.3 collection to match your LTI AGS line item ID:
	- https://34a7-190-142-38-224.ngrok-free.app/api/lti_consumer/v1/lti/{line_item_id}/lti-ags/1/scores
- Edit the "AGS Score" request "Body" tab and change the "userId" value to your external user ID.
- Go to the "AGS Score" request "Authorization" tab and change the token value to the generated access token.
- Send the POST request.
- You should receive a 200 response with the updated score.


## Reviewers

- [x] @Squirrel18 
- [x] @anfbermudezme 
- [x] @alexjmpb 
