### PR TITLE
PADV-503: Add LTI 1.3 public keyset endpoint 

### DIFF
--- a/lti_store/urls.py
+++ b/lti_store/urls.py
@@ -1,11 +1,16 @@
 from django.urls import path
 
-from lti_store.views import access_token_endpoint
+from lti_store.views import access_token_endpoint, public_keyset_endpoint
 
 urlpatterns = [
     path(
         "token/<int:lti_config_id>",
         access_token_endpoint,
         name="access_token",
+    ),
+    path(
+        'public_keyset/<int:lti_config_id>',
+        public_keyset_endpoint,
+        name='public_keyset',
     ),
 ]


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-503

## Description

This PR adds LTI 1.3 public keyset endpoint to the plugin views. This endpoint is used by LTI tools to request a public keyset instead of manually copying the platform public key.

## Type of Change

- [x] Add public_keyset_endpoint view.
- [x] Add URLS configuration.
- [x] Add test for public_keyset_endpoint view.

## Testing:

- Run the LMS: `make dev.up.lms`
- Install openedx-ltistore on the LMS.
- Add 'lti_consumer' to course advance setting 'Advanced Module List'.
- Add LTI 1.3 consumer XBlock to a course.
- Go to http://localhost:18000/lti_store/v1/public_keysets/{lti_config_id}
- The request should return a keyset.json file with the configuration public keyset.


## Reviewers

- [x] @alexjmpb 
- [x] @sergivalero20 
